### PR TITLE
Fix `rmtensor!`

### DIFF
--- a/src/Components/SimpleTensorNetwork.jl
+++ b/src/Components/SimpleTensorNetwork.jl
@@ -207,7 +207,7 @@ function rmtensor!(tn::SimpleTensorNetwork, tensor::Tensor)
     hastensor(tn, tensor) || throw(ArgumentError("Tensor not found"))
 
     target_vertex = vertex_at(tn, tensor)
-    edge_set = vertex_incidents(tn, target_vertex)
+    edge_set = vertex_incidents(tn, target_vertex) |> deepcopy
 
     # remove tensor
     delete!(tn.tensormap, target_vertex)
@@ -216,7 +216,11 @@ function rmtensor!(tn::SimpleTensorNetwork, tensor::Tensor)
     # remove indices if they were removed
     # TODO maybe we should refactor `rmtensor!` to check if we use a `Network` underneath and then, use the `RemoveVertexEffect` and `RemoveEdgeEffect` effects?
     for edge in edge_set
-        if !hasedge(tn, edge)
+        # Delete edge if it is not incident to any other tensor
+        vertex_set = edge_incidents(tn, edge)
+
+        if isempty(vertex_set)
+            rmedge!(tn.network, edge)
             delete!(tn.indmap, edge)
         end
     end


### PR DESCRIPTION
### Summary
This PR resolves #7 by fixing the `rmtensor!` function to properly remove the indices of a tensor network if we remove a `Tensor`.

### Example
```julia
julia> using Tangles
julia> test_tensors = [
           Tensor(rand(ComplexF64, 2, 3), Index.([:i, :j])),
           Tensor(rand(ComplexF64, 3, 4), Index.([:j, :k])),
           Tensor(rand(ComplexF64, 3, 4), Index.([:j, :k])),
       ]
3-element Vector{Tensor{ComplexF64, 2, Matrix{ComplexF64}}}: ...

julia> tn = SimpleTensorNetwork(test_tensors)
SimpleTensorNetwork (#tensors=3, #inds=3)

julia> rmtensor!(copy(tn), test_tensors[1]) # We remove a Tensor that has :i and :j indices
SimpleTensorNetwork (#tensors=2, #inds=2)
```